### PR TITLE
Clear animation queue on mouse over.

### DIFF
--- a/src/jquery.ui.potato.menu.js
+++ b/src/jquery.ui.potato.menu.js
@@ -62,6 +62,7 @@
       var $menuGroup = $parentMenuItem.find(option.menuGroupSelector + ':first').addClass(option.verticalClass);
       $parentMenuItem.hover(
         function (/*e*/) {
+          $menuGroup.stop(true, true);
           var offset = {left: '', top: ''};
           if (displayDirection == 'bottom') {
             offset.left = 0;


### PR DESCRIPTION
Adding code to clear the animation queue on a mouse over event, stopping the repeated flashing effect that occurs when the mouse moves over a menu item multiple times.
Fixes makotokw/jquery.ui.potato.menu#5